### PR TITLE
FIX: Support WSDL files with WSDL namespace being root

### DIFF
--- a/test/fixtures/wsdl/RootNamespace.wsdl
+++ b/test/fixtures/wsdl/RootNamespace.wsdl
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions name="StockQuote" targetNamespace="http://example.com/stockquote.wsdl" xmlns:tns="http://example.com/stockquote.wsdl" xmlns:xsd1="http://example.com/stockquote.xsd" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns="http://schemas.xmlsoap.org/wsdl/">
+  <types>
+    <schema targetNamespace="http://example.com/stockquote.xsd" xmlns="http://www.w3.org/2001/XMLSchema">
+      <element name="TradePriceRequest">
+        <complexType>
+          <all>
+            <element name="tickerSymbol" type="string"/>
+          </all>
+        </complexType>
+      </element>
+      <element name="TradePrice">
+        <complexType>
+          <all>
+            <element name="price" type="float"/>
+          </all>
+        </complexType>
+      </element>
+    </schema>
+  </types>
+  <message name="GetLastTradePriceInput">
+    <part name="body" element="xsd1:TradePriceRequest"/>
+  </message>
+  <message name="GetLastTradePriceOutput">
+    <part name="body" element="xsd1:TradePrice"/>
+  </message>
+  <portType name="StockQuotePortType">
+    <operation name="GetLastTradePrice">
+      <input message="tns:GetLastTradePriceInput"/>
+      <output message="tns:GetLastTradePriceOutput"/>
+    </operation>
+  </portType>
+  <binding name="StockQuoteSoapBinding" type="tns:StockQuotePortType">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="GetLastTradePrice">
+      <soap:operation soapAction="http://example.com/GetLastTradePrice"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+  </binding>
+  <service name="StockQuoteService">
+    <documentation>My first service</documentation>
+    <port name="StockQuotePort" binding="tns:StockQuoteBinding">
+      <soap:address location="http://example.com/stockquote"/>
+    </port>
+  </service>
+</definitions>

--- a/test/soap/wsdl_test.exs
+++ b/test/soap/wsdl_test.exs
@@ -43,7 +43,8 @@ defmodule Soap.WsdlTest do
       }
     ],
     schema_attributes: %{
-      element_form_default: "qualified", target_namespace: "com.esendex.ems.soapinterface"
+      element_form_default: "qualified",
+      target_namespace: "com.esendex.ems.soapinterface"
     },
     validation_types: %{
       "recipients" => %{
@@ -81,6 +82,31 @@ defmodule Soap.WsdlTest do
     }
   }
 
+  @parsed_root_namespace_wsdl %{
+    complex_types: [
+      %{name: "TradePriceRequest", type: ""},
+      %{name: "TradePrice", type: ""}
+    ],
+    endpoint: "http://example.com/stockquote",
+    namespaces: %{
+      "" => %{type: :soap, value: "http://schemas.xmlsoap.org/wsdl/"},
+      "soap" => %{type: :soap, value: "http://schemas.xmlsoap.org/wsdl/soap/"},
+      "tns" => %{type: :wsdl, value: "http://example.com/stockquote.wsdl"},
+      "xsd1" => %{type: :soap, value: "http://example.com/stockquote.xsd"}
+    },
+    operations: [
+      %{
+        name: "GetLastTradePrice",
+        soap_action: "http://example.com/GetLastTradePrice"
+      }
+    ],
+    schema_attributes: %{
+      element_form_default: "",
+      target_namespace: "http://example.com/stockquote.xsd"
+    },
+    validation_types: %{}
+  }
+
   test "#parse_from_file returns {:ok, wsdl}" do
     wsdl_path = Fixtures.get_file_path("wsdl/SendService.wsdl")
     assert(Wsdl.parse_from_file(wsdl_path) == {:ok, @parsed_wsdl})
@@ -98,6 +124,7 @@ defmodule Soap.WsdlTest do
 
   test "#get_namespaces returns correctly namespaces list" do
     schema_namespace = Wsdl.get_schema_namespace(@wsdl)
+
     namespaces_list = %{
       "soap" => %{type: :soap, value: "http://schemas.xmlsoap.org/wsdl/soap/"},
       "soap12" => %{type: :soap, value: "http://schemas.xmlsoap.org/wsdl/soap12/"},
@@ -114,6 +141,7 @@ defmodule Soap.WsdlTest do
 
   test "#get_complex_types returns list of types" do
     schema_namespace = Wsdl.get_schema_namespace(@wsdl)
+
     types = [
       %{name: "sendMessageMultipleRecipientsResponse", type: "tns:sendMessageMultipleRecipientsResponse"},
       %{name: "sendMessageMultipleRecipients", type: "tns:sendMessageMultipleRecipients"},
@@ -126,5 +154,10 @@ defmodule Soap.WsdlTest do
 
   test "#get_validation_types returns validation struct" do
     assert Wsdl.get_validation_types(@wsdl, "SendService.wsdl", "wsdl") == @parsed_wsdl.validation_types
+  end
+
+  test "support for root namespaces" do
+    wsdl_path = Fixtures.get_file_path("wsdl/RootNamespace.wsdl")
+    assert(Wsdl.parse_from_file(wsdl_path) == {:ok, @parsed_root_namespace_wsdl})
   end
 end


### PR DESCRIPTION
When having a WSDL file with the root namespace being "http://schemas.xmlsoap.org/wsdl/", parsing the file failed. This is fixed by this PR.