### PR TITLE
Add Soap.Response.parse/1

### DIFF
--- a/lib/soap/response.ex
+++ b/lib/soap/response.ex
@@ -18,7 +18,8 @@ defmodule Soap.Response do
   Executing with xml response body as string.
   parse/1 returns a full parsed response structure as map.
   """
-  @spec parse(String.t(), integer()) :: map()
+  @spec parse(__MODULE__.t | String.t(), integer()) :: map()
+  def parse(%Soap.Response{body: body, status_code: status_code} = response), do: parse(body, status_code)
   def parse(body, status_code) when status_code >= 400, do: Parser.parse(body, :fault)
   def parse(body, _status_code), do: Parser.parse(body, :successful)
 end

--- a/test/soap/response_test.exs
+++ b/test/soap/response_test.exs
@@ -4,14 +4,26 @@ defmodule Soap.ResponseTest do
   alias Soap.Response
   alias Soap.Response.Parser
 
-  test "#parse response, when request was successful" do
+  test "#Soap.Response.parse/1 from Soap.Response struct, when request was successful" do
+    response = %Response{
+      body: Fixtures.load_xml("send_service/SendMessageResponse.xml"),
+      headers: [],
+      request_url: "",
+      status_code: 200
+    }
+    correctly_parsed_response = %{response: %{message: "Hello!"}}
+
+    assert Response.parse(response) == correctly_parsed_response
+  end
+
+  test "#Soap.Response.parse/2, when request was successful" do
     xml_body = Fixtures.load_xml("send_service/SendMessageResponse.xml")
     correctly_parsed_response = %{response: %{message: "Hello!"}}
 
     assert Response.parse(xml_body, 200) == correctly_parsed_response
   end
 
-  test "#parse response, when response contains fault" do
+  test "#Soap.Response.parse/2, when response contains fault" do
     parsed_fault = %{
       faultcode: "soap:Server",
       faultstring: "System.Web.Services.Protocols.SoapException: Server was unable to process request."


### PR DESCRIPTION
I think it is more convenient in most cases to pass `Soap.Response` to parsing, instead of manual pattern matching. 
e.g.:
```elixir
{:ok, response} = Soap.call(wsdl, action, params)
Soap.Response.parse(response)
```