### PR TITLE
Fix dialyzer errors

### DIFF
--- a/lib/soap/type.ex
+++ b/lib/soap/type.ex
@@ -5,7 +5,7 @@ defmodule Soap.Type do
 
   import SweetXml, except: [parse: 1]
 
-  @spec get_complex_types(String.t(), String.t()) :: map()
+  @spec get_complex_types(SweetXml.xmlElement() | String.t(), String.t()) :: map()
   def get_complex_types(wsdl, x_path) do
     wsdl
     |> xpath(~x"#{x_path}"l)

--- a/lib/soap/wsdl.ex
+++ b/lib/soap/wsdl.ex
@@ -47,7 +47,7 @@ defmodule Soap.Wsdl do
     {:ok, parsed_response}
   end
 
-  @spec get_schema_namespace(String.t()) :: String.t()
+  @spec get_schema_namespace(SweetXml.xmlElement()) :: String.t()
   defp get_schema_namespace(wsdl) do
     {_, _, _, schema_namespace, _} =
       wsdl
@@ -57,14 +57,14 @@ defmodule Soap.Wsdl do
     schema_namespace
   end
 
-  @spec get_namespaces(String.t(), String.t(), String.t()) :: map()
+  @spec get_namespaces(SweetXml.xmlElement(), String.t(), String.t()) :: map()
   defp get_namespaces(wsdl, schema_namespace, protocol_ns) do
     wsdl
     |> xpath(~x"//#{ns("definitions", protocol_ns)}/namespace::*"l)
     |> Enum.into(%{}, &get_namespace(&1, wsdl, schema_namespace, protocol_ns))
   end
 
-  @spec get_namespace(tuple(), String.t(), String.t(), String.t()) :: tuple()
+  @spec get_namespace(tuple(), SweetXml.xmlElement(), String.t(), String.t()) :: tuple()
   defp get_namespace(namespaces_node, wsdl, schema_namespace, protocol_ns) do
     {_, _, _, key, value} = namespaces_node
     string_key = key |> to_string
@@ -85,7 +85,7 @@ defmodule Soap.Wsdl do
     end
   end
 
-  @spec get_endpoint(String.t(), String.t(), String.t()) :: String.t()
+  @spec get_endpoint(SweetXml.xmlElement(), String.t(), String.t()) :: String.t()
   def get_endpoint(wsdl, protocol_ns, soap_ns) do
     wsdl
     |> xpath(
@@ -93,7 +93,7 @@ defmodule Soap.Wsdl do
     )
   end
 
-  @spec get_complex_types(String.t(), String.t(), String.t()) :: list()
+  @spec get_complex_types(SweetXml.xmlElement(), String.t(), String.t()) :: list()
   defp get_complex_types(wsdl, namespace, protocol_ns) do
     xpath(
       wsdl,
@@ -103,7 +103,7 @@ defmodule Soap.Wsdl do
     )
   end
 
-  @spec get_validation_types(String.t(), String.t(), String.t(), String.t(), String.t(), keyword()) :: map()
+  @spec get_validation_types(SweetXml.xmlElement(), String.t(), String.t(), String.t(), String.t(), keyword()) :: map()
   def get_validation_types(wsdl, file_path, protocol_ns, schema_ns, endpoint, opts \\ []) do
     Map.merge(
       Type.get_complex_types(
@@ -117,7 +117,7 @@ defmodule Soap.Wsdl do
     )
   end
 
-  @spec get_schema_imports(String.t(), String.t(), String.t()) :: list()
+  @spec get_schema_imports(SweetXml.xmlElement(), String.t(), String.t()) :: list()
   def get_schema_imports(wsdl, protocol_ns, schema_ns) do
     xpath(
       wsdl,
@@ -126,7 +126,7 @@ defmodule Soap.Wsdl do
     )
   end
 
-  @spec get_full_paths(String.t(), String.t(), String.t(), String.t(), String.t()) :: list(String.t())
+  @spec get_full_paths(SweetXml.xmlElement(), String.t(), String.t(), String.t(), String.t()) :: list(String.t())
   defp get_full_paths(wsdl, path, protocol_ns, schema_namespace, endpoint) do
     wsdl
     |> get_schema_imports(protocol_ns, schema_namespace)
@@ -209,7 +209,7 @@ defmodule Soap.Wsdl do
     xpath(element, ~x"./#{ns("part", protocol_ns)}"l, name: ~x"./@name"s, element: ~x"./@element"s)
   end
 
-  @spec get_protocol_namespace(String.t()) :: String.t()
+  @spec get_protocol_namespace(SweetXml.xmlElement()) :: String.t()
   defp get_protocol_namespace(wsdl) do
     wsdl
     |> xpath(~x"//namespace::*"l)
@@ -217,7 +217,7 @@ defmodule Soap.Wsdl do
     |> elem(3)
   end
 
-  @spec get_soap_namespace(String.t(), list()) :: String.t()
+  @spec get_soap_namespace(SweetXml.xmlElement(), list()) :: String.t()
   defp get_soap_namespace(wsdl, opts) when is_list(opts) do
     version = soap_version(opts)
     namespace = @soap_version_namespaces[version]
@@ -228,7 +228,7 @@ defmodule Soap.Wsdl do
     |> elem(3)
   end
 
-  @spec get_schema_attributes(String.t()) :: map()
+  @spec get_schema_attributes(SweetXml.xmlElement()) :: map()
   defp get_schema_attributes(wsdl) do
     case xpath(wsdl, ~x"//*[local-name() = 'schema']") do
       nil ->


### PR DESCRIPTION
Dialyzer was complaining about when the wsdl parameter was `String.t()`, even though the correct type according to SweetXML docs for `SweetXml.parse/1` is `SweetXml.xmlElement()`. So I changed that and there are no more dialyzer errors